### PR TITLE
Fix TypeScript error in dashboard

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -43,7 +43,7 @@ interface DashboardSection {
 }
 
 // Helper to get icon component by name
-const IconComponents: Record<IconName, React.ElementType> = {
+const IconComponents: Partial<Record<IconName, React.ElementType>> = {
   FilePlus2,
   BedDouble,
   FileClock,


### PR DESCRIPTION
## Summary
- fix type error in dashboard page by using `Partial` for icon map

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841b157cf9883268913b30c3d8c1a17