### PR TITLE
Improve getting started docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Rename this file to .env.local and provide your Firebase config
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!*.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
-# Firebase Studio
+# AgendaQx
 
-This is a NextJS starter in Firebase Studio.
+A Next.js and Firebase web app for managing surgical schedules. The project was bootstrapped with Firebase Studio.
 
-To get started, take a look at src/app/page.tsx.
+## Prerequisites
+
+- **Node.js 20+** is recommended for running Next.js 15.
+- A **Firebase project** where you can obtain the web configuration values.
+- Copy `.env.local.example` to `.env.local` and fill in your Firebase credentials:
+
+```bash
+cp .env.local.example .env.local
+```
+
+## Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app runs on [http://localhost:9002](http://localhost:9002).
+3. (Optional) Start Genkit AI development flows:
+   ```bash
+   npm run genkit:dev
+   ```
+
+### Building for Production
+
+```bash
+npm run build
+npm run start
+```
+
+## Features
+
+Main functionality is outlined in `docs/blueprint.md`:
+- Dashboard with quick access to key areas.
+- Surgery registration forms for procedures and non-surgical patients.
+- Schedule management for surgeries and resources.
+- Daily logbook view of the current day's activities.
+- Authentication to restrict sensitive actions.
+
+## Project Structure
+
+- **`src/app`** – Next.js routes and layouts.
+- **`src/components`** – UI components used across features.
+- **`src/lib`** – Utilities and Firebase initialization (`src/lib/firebase.ts`).
+- **`src/ai`** – Genkit AI configuration.
+
+Refer to these directories when exploring or extending the application.


### PR DESCRIPTION
## Summary
- explain prerequisites and setup steps in README
- add sample environment file
- allow example env files in `.gitignore`

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TS2740 in dashboard page)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7c3cb30832694611062b69d9681