### PR TITLE
Guard console logs in dev

### DIFF
--- a/src/app/(app)/turnos/page.tsx
+++ b/src/app/(app)/turnos/page.tsx
@@ -23,6 +23,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 // Templates for shift types based on day of the week or specific labels
 // Day mapping: 0 for Sunday, 1 for Monday, ..., 6 for Saturday
 const shiftTemplates: Record<string, Omit<ShiftAssignment, 'id' | 'date' | 'assignedPersonnel'>> = {
@@ -144,38 +146,38 @@ export default function ShiftCalendarPage() {
   };
 
   const handlePrepareDeleteShift = () => {
-    console.log("[DEBUG] handlePrepareDeleteShift called. Selected Date:", selectedCalendarDate);
+    if (isDev) console.log("[DEBUG] handlePrepareDeleteShift called. Selected Date:", selectedCalendarDate);
     if (!selectedCalendarDate) {
       toast({ title: "Error", description: "Por favor, seleccione una fecha primero.", variant: "destructive" });
       return;
     }
     const assignmentToDelete = shiftAssignments.find(sa => isSameDay(sa.date, selectedCalendarDate));
-    console.log("[DEBUG] Found assignment to delete in handlePrepareDeleteShift:", assignmentToDelete);
+    if (isDev) console.log("[DEBUG] Found assignment to delete in handlePrepareDeleteShift:", assignmentToDelete);
     if (assignmentToDelete && assignmentToDelete.assignedPersonnel.length > 0) {
       setShiftToDelete(assignmentToDelete);
       setIsDeleteDialogOpen(true);
-      console.log("[DEBUG] Set shiftToDelete and opening delete dialog.");
+      if (isDev) console.log("[DEBUG] Set shiftToDelete and opening delete dialog.");
     } else if (assignmentToDelete) {
        toast({ title: "Información", description: "Este turno no tiene personal asignado para eliminar.", variant: "default" });
-       console.log("[DEBUG] Shift has no personnel, not deleting.");
+       if (isDev) console.log("[DEBUG] Shift has no personnel, not deleting.");
     } else {
       toast({ title: "Información", description: "No hay un turno asignado específico para esta fecha.", variant: "default" });
-      console.log("[DEBUG] No specific assignment for this date.");
+      if (isDev) console.log("[DEBUG] No specific assignment for this date.");
     }
   };
 
   const handleConfirmDeleteShift = () => {
-    console.log("[DEBUG] handleConfirmDeleteShift called. shiftToDelete:", shiftToDelete);
+    if (isDev) console.log("[DEBUG] handleConfirmDeleteShift called. shiftToDelete:", shiftToDelete);
     if (!shiftToDelete) {
       console.error("[DEBUG] shiftToDelete is null, cannot delete.");
       return;
     }
 
     setShiftAssignments(prevAssignments => {
-      console.log("[DEBUG] Current assignments before delete:", prevAssignments);
+      if (isDev) console.log("[DEBUG] Current assignments before delete:", prevAssignments);
       const newAssignments = prevAssignments.filter(sa => sa.id !== shiftToDelete.id);
-      console.log("[DEBUG] Assignments after filter (should be one less):", newAssignments);
-      console.log(`[DEBUG] Filtering based on id: ${shiftToDelete.id}`);
+      if (isDev) console.log("[DEBUG] Assignments after filter (should be one less):", newAssignments);
+      if (isDev) console.log(`[DEBUG] Filtering based on id: ${shiftToDelete.id}`);
       
       if (newAssignments.length === prevAssignments.length && prevAssignments.some(sa => sa.id === shiftToDelete.id)) {
         console.warn("[DEBUG] Filter did not remove any assignments. Check ID matching or object references.");
@@ -184,7 +186,7 @@ export default function ShiftCalendarPage() {
       try {
         localStorage.setItem(SHIFT_ASSIGNMENTS_STORAGE_KEY, JSON.stringify(newAssignments.map(sa => ({...sa, date: sa.date.toISOString()}))));
         toast({ title: "Turno Eliminado", description: `La asignación de personal para ${format(shiftToDelete.date, 'PPP', { locale: es})} ha sido eliminada.` });
-        console.log("[DEBUG] Successfully updated localStorage and toasted.");
+        if (isDev) console.log("[DEBUG] Successfully updated localStorage and toasted.");
       } catch (error) {
         console.error("[DEBUG] Error deleting shift assignment from localStorage:", error);
         toast({ title: "Error de Eliminación", description: "No se pudo eliminar la asignación del turno de localStorage.", variant: "destructive"});
@@ -194,11 +196,11 @@ export default function ShiftCalendarPage() {
     
     setIsDeleteDialogOpen(false);
     setShiftToDelete(null);
-    console.log("[DEBUG] Closed delete dialog and reset shiftToDelete.");
+    if (isDev) console.log("[DEBUG] Closed delete dialog and reset shiftToDelete.");
 
     if (editingShiftAssignment && shiftToDelete && editingShiftAssignment.id === shiftToDelete.id) {
         setEditingShiftAssignment(undefined);
-        console.log("[DEBUG] Cleared editingShiftAssignment.");
+        if (isDev) console.log("[DEBUG] Cleared editingShiftAssignment.");
     }
   };
 

--- a/src/components/admin/user-registration-form.tsx
+++ b/src/components/admin/user-registration-form.tsx
@@ -25,6 +25,8 @@ import { CheckCircle, Hourglass, UserPlus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useState } from 'react';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const userRegistrationSchema = z.object({
   nombreCompleto: z.string().min(3, { message: 'El nombre completo debe tener al menos 3 caracteres.' }),
   email: z.string().email({ message: 'Dirección de correo electrónico inválida.' }),
@@ -55,7 +57,7 @@ export default function UserRegistrationForm() {
 
   async function onSubmit(values: UserRegistrationFormValues) {
     setIsSubmitting(true);
-    console.log('Datos de Registro de Usuario:', values);
+    if (isDev) console.log('Datos de Registro de Usuario:', values);
 
     // Simulate API call
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/components/agenda/daily-log.tsx
+++ b/src/components/agenda/daily-log.tsx
@@ -18,6 +18,8 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useToast } from '@/hooks/use-toast';
 import { differenceInHours, parseISO, isValid, isToday, format } from 'date-fns';
+
+const isDev = process.env.NODE_ENV !== 'production';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -275,10 +277,10 @@ export default function DailyLog() {
       let allSurgeries: Surgery[];
       const storedSurgeriesJSON = localStorage.getItem(MOCK_SURGERIES_STORAGE_KEY);
       if (storedSurgeriesJSON && storedSurgeriesJSON !== 'null' && storedSurgeriesJSON !== 'undefined') {
-        console.log("Loading surgeries from localStorage");
+        if (isDev) console.log("Loading surgeries from localStorage");
         allSurgeries = JSON.parse(storedSurgeriesJSON);
       } else {
-        console.log("Initializing MOCK_SURGERIES_STORAGE_KEY with example data.");
+        if (isDev) console.log("Initializing MOCK_SURGERIES_STORAGE_KEY with example data.");
         allSurgeries = initialSurgeries;
         localStorage.setItem(MOCK_SURGERIES_STORAGE_KEY, JSON.stringify(allSurgeries));
       }
@@ -294,10 +296,10 @@ export default function DailyLog() {
       let allNonSurgical: NonSurgicalPatient[];
       const storedNonSurgicalJSON = localStorage.getItem(MOCK_NON_SURGICAL_STORAGE_KEY);
       if (storedNonSurgicalJSON && storedNonSurgicalJSON !== 'null' && storedNonSurgicalJSON !== 'undefined') {
-         console.log("Loading non-surgical from localStorage");
+         if (isDev) console.log("Loading non-surgical from localStorage");
         allNonSurgical = JSON.parse(storedNonSurgicalJSON);
       } else {
-        console.log("Initializing MOCK_NON_SURGICAL_STORAGE_KEY with example data.");
+        if (isDev) console.log("Initializing MOCK_NON_SURGICAL_STORAGE_KEY with example data.");
         allNonSurgical = initialNonSurgicalPatients;
         localStorage.setItem(MOCK_NON_SURGICAL_STORAGE_KEY, JSON.stringify(allNonSurgical));
       }
@@ -313,10 +315,10 @@ export default function DailyLog() {
       let allNovelties: ShiftNovelty[];
       const storedNoveltiesJSON = localStorage.getItem(MOCK_NOVELTIES_STORAGE_KEY);
       if (storedNoveltiesJSON && storedNoveltiesJSON !== 'null' && storedNoveltiesJSON !== 'undefined') {
-        console.log("Loading novelties from localStorage");
+        if (isDev) console.log("Loading novelties from localStorage");
         allNovelties = JSON.parse(storedNoveltiesJSON);
       } else {
-        console.log("Initializing MOCK_NOVELTIES_STORAGE_KEY with example data.");
+        if (isDev) console.log("Initializing MOCK_NOVELTIES_STORAGE_KEY with example data.");
         allNovelties = initialShiftNovelties;
         localStorage.setItem(MOCK_NOVELTIES_STORAGE_KEY, JSON.stringify(allNovelties));
       }
@@ -368,7 +370,7 @@ export default function DailyLog() {
 
 
   const isEditable = (entryTimestamp?: string): boolean => {
-    console.log("[isEditable] Checking timestamp:", entryTimestamp);
+    if (isDev) console.log("[isEditable] Checking timestamp:", entryTimestamp);
     if (!entryTimestamp) {
       console.warn("[isEditable] entryTimestamp is missing. Defaulting to not editable.");
       return false;
@@ -380,13 +382,13 @@ export default function DailyLog() {
     }
     const hoursDifference = differenceInHours(new Date(), entryDate);
     const editable = hoursDifference <= 24;
-    console.log(`[isEditable] Entry TS: ${entryTimestamp}, Parsed Entry Date: ${entryDate.toISOString()}, Now: ${new Date().toISOString()}, Diff (hours): ${hoursDifference}, Editable: ${editable}`);
+    if (isDev) console.log(`[isEditable] Entry TS: ${entryTimestamp}, Parsed Entry Date: ${entryDate.toISOString()}, Now: ${new Date().toISOString()}, Diff (hours): ${hoursDifference}, Editable: ${editable}`);
     return editable;
   };
 
   const handleEdit = (itemId: string, itemType: string, entryTimestamp: string | undefined) => {
     const editable = isEditable(entryTimestamp);
-    console.log(`[handleEdit] Attempting to edit ${itemType} ID: ${itemId} with timestamp: ${entryTimestamp}, Editable: ${editable}`);
+    if (isDev) console.log(`[handleEdit] Attempting to edit ${itemType} ID: ${itemId} with timestamp: ${entryTimestamp}, Editable: ${editable}`);
     if (editable) {
       toast({
         title: "Edición Permitida (Próximamente)",
@@ -408,7 +410,7 @@ export default function DailyLog() {
 
   const handleConfirmDelete = () => {
     if (!itemToDelete) return;
-    console.log("[handleConfirmDelete] Deleting item:", itemToDelete);
+    if (isDev) console.log("[handleConfirmDelete] Deleting item:", itemToDelete);
 
     let updatedSurgeries = [...todaysSurgeries];
     let updatedNonSurgical = [...nonSurgicalPatients];
@@ -418,15 +420,15 @@ export default function DailyLog() {
     if (itemToDelete.type === 'surgery') {
       updatedSurgeries = todaysSurgeries.filter(s => s.id !== itemToDelete.id);
       itemFoundAndRemoved = updatedSurgeries.length < todaysSurgeries.length;
-      console.log(`[handleConfirmDelete] Surgeries after delete attempt (found: ${itemFoundAndRemoved}):`, updatedSurgeries);
+      if (isDev) console.log(`[handleConfirmDelete] Surgeries after delete attempt (found: ${itemFoundAndRemoved}):`, updatedSurgeries);
     } else if (itemToDelete.type === 'non-surgical') {
       updatedNonSurgical = nonSurgicalPatients.filter(p => p.id !== itemToDelete.id);
       itemFoundAndRemoved = updatedNonSurgical.length < nonSurgicalPatients.length;
-      console.log(`[handleConfirmDelete] Non-surgical after delete attempt (found: ${itemFoundAndRemoved}):`, updatedNonSurgical);
+      if (isDev) console.log(`[handleConfirmDelete] Non-surgical after delete attempt (found: ${itemFoundAndRemoved}):`, updatedNonSurgical);
     } else if (itemToDelete.type === 'novelty') {
       updatedNovelties = shiftNovelties.filter(n => n.id !== itemToDelete.id);
       itemFoundAndRemoved = updatedNovelties.length < shiftNovelties.length;
-      console.log(`[handleConfirmDelete] Novelties after delete attempt (found: ${itemFoundAndRemoved}):`, updatedNovelties);
+      if (isDev) console.log(`[handleConfirmDelete] Novelties after delete attempt (found: ${itemFoundAndRemoved}):`, updatedNovelties);
     }
 
     if (itemFoundAndRemoved) {

--- a/src/components/cirugias/non-surgical-registration-form.tsx
+++ b/src/components/cirugias/non-surgical-registration-form.tsx
@@ -19,6 +19,8 @@ import { CheckCircle, Hourglass } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useState } from 'react';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const nonSurgicalSchema = z.object({
   nombrePaciente: z.string().min(2, { message: 'El nombre del paciente debe tener al menos 2 caracteres.' }),
   edad: z.coerce.number({ invalid_type_error: 'La edad debe ser un número.' }).int().positive({ message: 'La edad debe ser un número positivo.' }).min(0, { message: 'La edad no puede ser negativa.' }),
@@ -48,7 +50,7 @@ export default function NonSurgicalRegistrationForm() {
 
   async function onSubmit(values: NonSurgicalFormValues) {
     setIsSubmitting(true);
-    console.log('Datos de Registro No Quirúrgico:', values);
+    if (isDev) console.log('Datos de Registro No Quirúrgico:', values);
     await new Promise(resolve => setTimeout(resolve, 1500));
     
     toast({

--- a/src/components/cirugias/pending-surgery-form.tsx
+++ b/src/components/cirugias/pending-surgery-form.tsx
@@ -20,6 +20,8 @@ import { CheckCircle, Hourglass } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useState } from 'react';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const pendingSurgerySchema = z.object({
   tipoIntervencion: z.enum(['cirugia', 'procedimiento'], {
     required_error: 'Debe seleccionar el tipo de intervención.',
@@ -51,7 +53,7 @@ export default function PendingSurgeryForm() {
 
   async function onSubmit(values: PendingSurgeryFormValues) {
     setIsSubmitting(true);
-    console.log('Datos de Cirugía Pendiente:', values);
+    if (isDev) console.log('Datos de Cirugía Pendiente:', values);
     await new Promise(resolve => setTimeout(resolve, 1500));
     
     toast({

--- a/src/components/cirugias/shift-novelties-form.tsx
+++ b/src/components/cirugias/shift-novelties-form.tsx
@@ -19,6 +19,8 @@ import { CheckCircle, Hourglass, User, CalendarDays } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useState, useEffect } from 'react';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const shiftNoveltySchema = z.object({
   comentarioNovedad: z.string().min(1, { message: 'El comentario o novedad es obligatorio.' }).max(2000, {message: 'El comentario no puede exceder los 2000 caracteres.'}),
 });
@@ -54,7 +56,7 @@ export default function ShiftNoveltiesForm() {
       fechaHora: new Date().toISOString(), // Actual submission timestamp
       cirujano: surgeonName,
     }
-    console.log('Datos de Novedad del Turno:', submissionData);
+    if (isDev) console.log('Datos de Novedad del Turno:', submissionData);
     await new Promise(resolve => setTimeout(resolve, 1500));
     
     toast({

--- a/src/components/cirugias/surgery-registration-form.tsx
+++ b/src/components/cirugias/surgery-registration-form.tsx
@@ -22,6 +22,8 @@ import { useState } from 'react';
 import type { Surgery } from '@/lib/types';
 import { MOCK_SURGERIES_STORAGE_KEY } from '@/lib/constants';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const surgeryRegistrationSchema = z.object({
   tipoIntervencion: z.enum(['cirugia', 'procedimiento'], {
     required_error: 'Debe seleccionar el tipo de intervención.',
@@ -87,7 +89,7 @@ export default function SurgeryRegistrationForm() {
       operatingRoom: values.ubicacionCama, // Or a more specific parsing
     };
 
-    console.log('Datos de Registro Quirúrgico a Guardar:', newSurgery);
+    if (isDev) console.log('Datos de Registro Quirúrgico a Guardar:', newSurgery);
 
     try {
       const existingSurgeriesJSON = localStorage.getItem(MOCK_SURGERIES_STORAGE_KEY);

--- a/src/components/turnos/assign-shift-personnel-dialog.tsx
+++ b/src/components/turnos/assign-shift-personnel-dialog.tsx
@@ -27,6 +27,8 @@ import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 interface AssignShiftPersonnelDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -65,7 +67,7 @@ export default function AssignShiftPersonnelDialog({
     // It uses a deep copy of currentAssignments to prevent direct mutation
     // and to ensure local state is distinct from parent state until saved.
     if (isOpen && selectedDate) {
-      console.log('Dialog Effect: Initializing/Resetting personnel for date:', selectedDate.toISOString(), 'with currentAssignments:', currentAssignments);
+      if (isDev) console.log('Dialog Effect: Initializing/Resetting personnel for date:', selectedDate.toISOString(), 'with currentAssignments:', currentAssignments);
       setPersonnel(JSON.parse(JSON.stringify(currentAssignments)));
       setSelectedSurgeonId('');
       setSelectedRole('');
@@ -93,17 +95,17 @@ export default function AssignShiftPersonnelDialog({
   };
 
   const handleRemovePersonnel = (surgeonIdToRemove: string) => {
-    console.log('handleRemovePersonnel called for surgeonId:', surgeonIdToRemove);
-    console.log('Personnel state BEFORE removal:', personnel);
+    if (isDev) console.log('handleRemovePersonnel called for surgeonId:', surgeonIdToRemove);
+    if (isDev) console.log('Personnel state BEFORE removal:', personnel);
     setPersonnel(prevPersonnel => {
       const updatedPersonnel = prevPersonnel.filter(p => p.surgeonId !== surgeonIdToRemove);
-      console.log('Personnel state AFTER removal (updatedPersonnel):', updatedPersonnel);
+      if (isDev) console.log('Personnel state AFTER removal (updatedPersonnel):', updatedPersonnel);
       return updatedPersonnel;
     });
   };
 
   const handleSaveChanges = () => {
-    console.log('Saving changes with personnel:', personnel);
+    if (isDev) console.log('Saving changes with personnel:', personnel);
     onSave(personnel);
   };
 
@@ -185,7 +187,7 @@ export default function AssignShiftPersonnelDialog({
                         variant="ghost" 
                         size="icon" 
                         onClick={() => {
-                          console.log(`Delete button clicked for surgeonId: ${p.surgeonId}`);
+                          if (isDev) console.log(`Delete button clicked for surgeonId: ${p.surgeonId}`);
                           handleRemovePersonnel(p.surgeonId);
                         }} 
                         className="text-destructive hover:text-destructive/80 h-8 w-8"


### PR DESCRIPTION
## Summary
- add `isDev` constant across forms and pages
- wrap `console.log` statements behind `isDev` guards

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7c0decc83268e26d338581d6d06